### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.1.0 to 4.1.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -26,4 +26,4 @@ version.kotlin=1.3.50
 
 version.io.kotest..kotest-runner-junit5-jvm=4.1.0
 
-version.io.kotest..kotest-assertions-core-jvm=4.1.0
+version.io.kotest..kotest-assertions-core-jvm=4.1.1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.