### PR TITLE
Upgrade kotest from 4.1.3 to 4.2.0.RC1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,6 +14,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 version.io.github.classgraph..classgraph=4.8.87
 
-version.kotest=4.1.3
+version.kotest=4.2.0.RC1
 
 version.kotlin=1.3.50


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.