### PR TITLE
Upgrade kotest from 4.2.2 to 4.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,6 +15,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 version.io.github.classgraph..classgraph=4.8.89
 
-version.kotest=4.2.2
+version.kotest=4.2.3
 
 version.kotlin=1.3.50


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.