### PR TITLE
Upgrade kotest from 4.2.6 to 4.3.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,6 +15,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version.io.github.classgraph..classgraph=4.8.90
 
-version.kotest=4.2.6
+version.kotest=4.3.0
 
 version.kotlin=1.4.10


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.