### PR TITLE
Upgrade classgraph from 4.8.98 to 4.8.100

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -13,7 +13,7 @@ plugin.org.danilopianini.publish-on-central=0.4.1
 
 plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
-version.io.github.classgraph..classgraph=4.8.98
+version.io.github.classgraph..classgraph=4.8.100
 
 version.kotest=4.3.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.