### PR TITLE
Upgrade publish-on-central from 0.4.1 to 0.4.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,7 +9,7 @@ plugin.io.gitlab.arturbosch.detekt=1.15.0
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
-plugin.org.danilopianini.publish-on-central=0.4.1
+plugin.org.danilopianini.publish-on-central=0.4.2
 
 plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.