### PR TITLE
Upgrade kotest from 4.4.0 to 4.4.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,6 +15,6 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version.io.github.classgraph..classgraph=4.8.102
 
-version.kotest=4.4.0
+version.kotest=4.4.1
 
 version.kotlin=1.4.30


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.