### PR TITLE
Upgrade kotest from 4.4.1 to 4.4.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,6 +15,6 @@ plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 
 version.io.github.classgraph..classgraph=4.8.102
 
-version.kotest=4.4.1
+version.kotest=4.4.2
 
 version.kotlin=1.4.31


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.