### PR TITLE
Upgrade kotlin from 1.4.31 to 1.4.32

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,4 +17,4 @@ version.io.github.classgraph..classgraph=4.8.102
 
 version.kotest=4.4.3
 
-version.kotlin=1.4.31
+version.kotlin=1.4.32


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.