### PR TITLE
Upgrade kotest from 4.5.0 to 4.6.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,6 +17,6 @@ plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 
 version.io.github.classgraph..classgraph=4.8.105
 
-version.kotest=4.5.0
+version.kotest=4.6.0
 
 version.kotlin=1.5.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.