### PR TITLE
Upgrade kotest from 4.6.0 to 4.6.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,6 +17,6 @@ plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 
 version.io.github.classgraph..classgraph=4.8.110
 
-version.kotest=4.6.0
+version.kotest=4.6.1
 
 version.kotlin=1.5.20


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.